### PR TITLE
ECVRF: require s < q in ECVRF_decode_proof

### DIFF
--- a/draft-irtf-cfrg-vrf.xml
+++ b/draft-irtf-cfrg-vrf.xml
@@ -10,7 +10,7 @@
 <?rfc comments="yes"?>
 <?rfc inline="yes"?>
 
-<rfc category="std" docName="draft-irtf-cfrg-vrf-09" ipr="trust200902">
+<rfc category="std" docName="draft-irtf-cfrg-vrf-10" ipr="trust200902">
     <front>
         <title abbrev="VRF">Verifiable Random Functions (VRFs)</title>
 
@@ -1625,6 +1625,7 @@
                 <t> 07 - Incorporated hash-to-curve draft by reference to replace our own Elligator2 and Simple SWU. Clarified discussion of EC parameters and functions. Added a 0 octet to all hashing to enforce domain separation from hashing done inside hash-to-curve.</t>
 		        <t> 08 - Incorporated suggestions from crypto panel review by Chloe Martindale. Changed Reyzin's affiliation. Updated references.</t>
                 <t> 09 - Added a note to remove the implementation page before publication.</t>
+                <t> 10 - Added a check in ECVRF_decode_proof to ensure that s is reduced mod q.</t>
             </list>
         </t>
     </section>

--- a/draft-irtf-cfrg-vrf.xml
+++ b/draft-irtf-cfrg-vrf.xml
@@ -1030,7 +1030,7 @@
                     c - integer between 0 and 2^(8n)-1
                     </t>
                     <t>
-                    s - integer between 0 and 2^(8qLen)-1
+                    s - integer between 0 and q-1
                     </t>
                 </list>
             </t>
@@ -1041,9 +1041,10 @@
                     <t>let c_string = pi_string[ptLen]...pi_string[ptLen+n-1]</t>
                     <t>let s_string =pi_string[ptLen+n]...pi_string[ptLen+n+qLen-1]</t>
                     <t>Gamma = string_to_point(gamma_string)</t>
-                    <t>if Gamma = "INVALID" output "INVALID" and stop.</t>
+                    <t>if Gamma = "INVALID" output "INVALID" and stop</t>
                     <t>c = string_to_int(c_string)</t>
                     <t>s = string_to_int(s_string)</t>
+                    <t>if s >= q output "INVALID" and stop</t>
                     <t>Output Gamma, c, and s</t>
                 </list>
             </t>


### PR DESCRIPTION
This PR changes the ECVRF_decode_proof procedure such that it will reject any proof whose `s` value is not encoded as an integer `0 <= s < q`.

The reason for this change is that in its absence one can maul a valid proof `(G, c, s)` into a different byte string, `(G, c, s+q)`. Note that mauling a proof in this way does not change the output of ECVRF_proof_to_hash.